### PR TITLE
replace push_str with direct file write, fix clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,9 @@ jobs:
         with:
           components: clippy
 
-        # strict version that does not allow _any_ wclippy warnings to pass
-      # - run: cargo clippy -- -D warnings
-        # allows warnings to pass (but still not errors)
-      - run: cargo clippy --all-features --all-targets
+      # strict version that does not allow _any_ clippy warnings to pass
+      # this prevents us from introducing potential issues.
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   format:
     name: Format (rustfmt)

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -281,12 +281,9 @@ pub fn makecliffs(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
                     if steep.is_nan() {
                         steep = -flat_place;
                     }
-                    if steep < 0.0 {
-                        steep = 0.0;
-                    }
-                    if steep > 17.0 {
-                        steep = 17.0;
-                    }
+
+                    steep = steep.clamp(0.0, 17.0);
+
                     let bonus =
                         (c2_limit - c1_limit) * (1.0 - (no_small_ciffs - steep) / no_small_ciffs);
                     let limit = c1_limit + bonus;

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -30,14 +30,14 @@ pub fn makecliffs(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
         no_small_ciffs -= flat_place;
     }
 
-    let mut xmin: f64 = std::f64::MAX;
-    let mut xmax: f64 = std::f64::MIN;
+    let mut xmin: f64 = f64::MAX;
+    let mut xmax: f64 = f64::MIN;
 
-    let mut ymin: f64 = std::f64::MAX;
-    let mut ymax: f64 = std::f64::MIN;
+    let mut ymin: f64 = f64::MAX;
+    let mut ymax: f64 = f64::MIN;
 
-    let mut hmin: f64 = std::f64::MAX;
-    let mut hmax: f64 = std::f64::MIN;
+    let mut hmin: f64 = f64::MAX;
+    let mut hmax: f64 = f64::MIN;
 
     let tmpfolder = format!("temp{}", thread);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,8 @@ impl Config {
         let cliffsonly: bool = gs.get("cliffsonly").unwrap_or("0") == "1";
         let contoursonly: bool = gs.get("contoursonly").unwrap_or("0") == "1";
 
+        #[allow(clippy::nonminimal_bool)]
+        // clippy complains about this, but we want it like this for understandability
         if (vegeonly && (cliffsonly || contoursonly))
             || (cliffsonly && (vegeonly || contoursonly))
             || (contoursonly && (vegeonly || cliffsonly))

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -24,14 +24,14 @@ pub fn xyz2contours(
 
     let tmpfolder = format!("temp{}", thread);
 
-    let mut xmin: f64 = std::f64::MAX;
-    let mut xmax: f64 = std::f64::MIN;
+    let mut xmin: f64 = f64::MAX;
+    let mut xmax: f64 = f64::MIN;
 
-    let mut ymin: f64 = std::f64::MAX;
-    let mut ymax: f64 = std::f64::MIN;
+    let mut ymin: f64 = f64::MAX;
+    let mut ymax: f64 = f64::MIN;
 
-    let mut hmin: f64 = std::f64::MAX;
-    let mut hmax: f64 = std::f64::MIN;
+    let mut hmin: f64 = f64::MAX;
+    let mut hmax: f64 = f64::MIN;
 
     let path = format!("{}/{}", tmpfolder, xyzfilein);
     let xyz_file_in = Path::new(&path);

--- a/src/contours.rs
+++ b/src/contours.rs
@@ -413,10 +413,10 @@ pub fn xyz2contours(
                         .expect("Cannot write to output file");
                     let mut res = (x, y);
 
-                    let (x, y) = *curves.get(&k).unwrap();
+                    let (x, y) = *curves.get(k).unwrap();
                     write!(&mut f, "{},{};", x as f64 / 100.0, y as f64 / 100.0)
                         .expect("Cannot write to output file");
-                    curves.remove(&k);
+                    curves.remove(k);
 
                     let mut head = (x, y);
 

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -139,7 +139,6 @@ pub fn dotknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>>
             let y: f64 = r[2].parse::<f64>().unwrap();
             let mut ok = true;
             let mut i = (x - xstart) / scalefactor - 3.0;
-            let mut layer = String::new();
             while i < (x - xstart) / scalefactor + 4.0 && ok {
                 let mut j = (y - ystart) / scalefactor - 3.0;
                 while j < (y - ystart) / scalefactor + 4.0 && ok {
@@ -156,14 +155,14 @@ pub fn dotknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>>
                 }
                 i += 1.0;
             }
-            if !ok {
-                layer = String::from("ugly");
-            }
-            if depression {
-                layer.push_str("dotknoll")
-            } else {
-                layer.push_str("udepression")
-            }
+
+            let layer = match (ok, depression) {
+                (true, true) => "dotknoll",
+                (true, false) => "udepression",
+                (false, true) => "uglydotknoll",
+                (false, false) => "uglyudepression",
+            };
+
             write!(
                 &mut f,
                 "POINT\r\n  8\r\n{}\r\n 10\r\n{}\r\n 20\r\n{}\r\n 50\r\n0\r\n  0\r\n",

--- a/src/knolls.rs
+++ b/src/knolls.rs
@@ -1155,12 +1155,8 @@ pub fn xyzknolls(config: &Config, thread: &String) -> Result<(), Box<dyn Error>>
             }
         }
         let mut range = *dist.get(&l).unwrap_or(&0.0) * 0.8 - 1.0;
-        if range < 1.0 {
-            range = 1.0;
-        }
-        if range > 12.0 {
-            range = 12.0;
-        }
+        range = range.clamp(1.0, 12.0);
+
         for iii in 0..((range * 2.0 + 1.0) as usize) {
             for jjj in 0..((range * 2.0 + 1.0) as usize) {
                 let ii: f64 = xx - range + iii as f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// we use a lot of manual indices instead of `take` and `skip`, so allow that
+#![allow(clippy::needless_range_loop)]
+
 pub mod blocks;
 pub mod canvas;
 pub mod cliffs;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1068,6 +1068,8 @@ pub fn smoothjoin(config: &Config, thread: &String) -> Result<(), Box<dyn Error>
                     xa[el_x_len - 1] = el_x[l][el_x_len - 1];
                     ya[el_x_len - 1] = el_y[l][el_x_len - 1];
                 }
+
+                #[allow(clippy::manual_memcpy)]
                 for k in 0..el_x_len {
                     el_x[l][k] = xa[k];
                     el_y[l][k] = ya[k];

--- a/src/process.rs
+++ b/src/process.rs
@@ -24,7 +24,7 @@ use crate::vegetation;
 pub fn process_zip(
     config: &Config,
     thread: &String,
-    filenames: &Vec<String>,
+    filenames: &[String],
 ) -> Result<(), Box<dyn Error>> {
     let mut timing = Timing::start_now("process_zip");
     let &Config {
@@ -290,12 +290,10 @@ pub fn process_tile(
         timing.start_section("cliff generation");
         cliffs::makecliffs(config, thread).unwrap();
     }
-    if !vegeonly && !contoursonly && !cliffsonly {
-        if config.detectbuildings {
-            info!("{}Detecting buildings", thread_name);
-            timing.start_section("detecting buildings");
-            blocks::blocks(thread).unwrap();
-        }
+    if !vegeonly && !contoursonly && !cliffsonly && config.detectbuildings {
+        info!("{}Detecting buildings", thread_name);
+        timing.start_section("detecting buildings");
+        blocks::blocks(thread).unwrap();
     }
     if !skip_rendering && !vegeonly && !contoursonly && !cliffsonly {
         info!("{}Rendering png map with depressions", thread_name);

--- a/src/process.rs
+++ b/src/process.rs
@@ -51,7 +51,7 @@ pub fn process_zip(
 pub fn unzipmtk(
     config: &Config,
     thread: &String,
-    filenames: &Vec<String>,
+    filenames: &[String],
 ) -> Result<(), Box<dyn Error>> {
     if Path::new(&format!("temp{}/low.png", thread)).exists() {
         fs::remove_file(format!("temp{}/low.png", thread)).unwrap();
@@ -238,11 +238,11 @@ pub fn process_tile(
         if !skipknolldetection {
             info!("{}Knoll detection part 2", thread_name);
             timing.start_section("knoll detection part 2");
-            knolls::knolldetector(&config, thread).unwrap();
+            knolls::knolldetector(config, thread).unwrap();
         }
         info!("{}Contour generation part 1", thread_name);
         timing.start_section("contour generation part 1");
-        knolls::xyzknolls(&config, thread).unwrap();
+        knolls::xyzknolls(config, thread).unwrap();
 
         info!("{}Contour generation part 2", thread_name);
         timing.start_section("contour generation part 2");
@@ -662,7 +662,7 @@ pub fn batch_process(conf: &Config, thread: &String) {
                 img.save(Path::new(&format!("{}/{}_vege.png", batchoutfolder, laz)))
                     .expect("could not save output png");
 
-                let pgw_file_out = File::create(&format!("{}/{}_vege.pgw", batchoutfolder, laz))
+                let pgw_file_out = File::create(format!("{}/{}_vege.pgw", batchoutfolder, laz))
                     .expect("Unable to create file");
                 let mut pgw_file_out = BufWriter::new(pgw_file_out);
                 write!(

--- a/src/render.rs
+++ b/src/render.rs
@@ -1199,7 +1199,7 @@ pub fn render(
                         (i as f32 + (angle.tan() * (h as f64) * 600.0 / 254.0 / scalefactor) as f32)
                             as f32
                             + m as f32,
-                        (h as f32 * 600.0 / 254.0 / scalefactor as f32) as f32,
+                        (h as f32 * 600.0 / 254.0 / scalefactor as f32),
                     ),
                     Rgba([0, 0, 200, 255]),
                 );
@@ -1258,8 +1258,8 @@ pub fn render(
         let blockpurple = image::imageops::crop(&mut blockpurple, 0, 0, w, h).to_image();
         let blockpurple_thumb = image::imageops::resize(
             &blockpurple,
-            new_width as u32,
-            new_height as u32,
+            new_width,
+            new_height,
             image::imageops::FilterType::Nearest,
         );
 
@@ -1291,8 +1291,8 @@ pub fn render(
         let imgbb = image::imageops::crop(&mut imgbb, 0, 0, w, h).to_image();
         let imgbb_thumb = image::imageops::resize(
             &imgbb,
-            new_width as u32,
-            new_height as u32,
+            new_width,
+            new_height,
             image::imageops::FilterType::Nearest,
         );
         image::imageops::overlay(&mut img, &imgbb_thumb, 0, 0);
@@ -1488,8 +1488,8 @@ pub fn render(
         let high = high_reader.decode().unwrap();
         let high_thumb = image::imageops::resize(
             &high,
-            new_width as u32,
-            new_height as u32,
+            new_width,
+            new_height,
             image::imageops::FilterType::Nearest,
         );
         image::imageops::overlay(&mut img, &high_thumb, 0, 0);

--- a/src/render.rs
+++ b/src/render.rs
@@ -122,10 +122,8 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                     }
                 }
                 let mut versuh = 0.0;
-                if let Some(fv) = record.get("VERSUH") {
-                    if let FieldValue::Numeric(Some(f_versuh)) = fv {
-                        versuh = *f_versuh;
-                    }
+                if let Some(FieldValue::Numeric(Some(f_versuh))) = record.get("VERSUH") {
+                    versuh = *f_versuh;
                 }
                 // water streams
                 if ["36311", "36312"].contains(&luokka.as_str()) {
@@ -338,10 +336,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.to_string().trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -364,10 +362,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -390,10 +388,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -416,10 +414,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -442,10 +440,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -468,10 +466,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -497,10 +495,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::new();
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -527,10 +525,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -553,10 +551,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -580,10 +578,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -607,10 +605,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -634,10 +632,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -660,10 +658,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -686,10 +684,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -713,10 +711,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -738,10 +736,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -763,10 +761,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -787,10 +785,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -811,10 +809,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -835,10 +833,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -859,10 +857,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {
@@ -883,10 +881,10 @@ pub fn mtkshaperender(config: &Config, thread: &String) -> Result<(), Box<dyn Er
                             let mut is_ok = true;
                             for keyval in keyvals.iter() {
                                 let mut r = String::from("");
-                                if let Some(recordfv) = record.get(&keyval.1) {
-                                    if let FieldValue::Character(Some(record_str)) = recordfv {
-                                        r = record_str.to_string().trim().to_string();
-                                    }
+                                if let Some(FieldValue::Character(Some(record_str))) =
+                                    record.get(&keyval.1)
+                                {
+                                    r = record_str.trim().to_string();
                                 }
                                 if keyval.0 == "=" {
                                     if r != keyval.2 {

--- a/src/vegetation.rs
+++ b/src/vegetation.rs
@@ -564,11 +564,11 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
             }
             let xx = ((x / bf32 / step).floor()) as u64;
             let yy = ((y / bf32 / step).floor()) as u64;
-            let foo = *ug.get(&(xx, yy)).unwrap_or(&0) as f64
+            let value = *ug.get(&(xx, yy)).unwrap_or(&0) as f64
                 / (*ug.get(&(xx, yy)).unwrap_or(&0) as f64
                     + { *ugg.get(&(xx, yy)).unwrap_or(&0.0) }
                     + 0.01);
-            if foo > uglimit {
+            if value > uglimit {
                 draw_line_segment_mut(
                     &mut imgug,
                     (
@@ -630,7 +630,7 @@ pub fn makevege(config: &Config, thread: &String) -> Result<(), Box<dyn Error>> 
                     )
                 }
             }
-            if foo > uglimit2 {
+            if value > uglimit2 {
                 draw_line_segment_mut(
                     &mut imgug,
                     (tmpfactor * x, tmpfactor * (hf32 * bf32 - y - bf32 * 3.0)),


### PR DESCRIPTION
Went ahead and removed almost all of the last occurrences of `push_str` and instead write directly to the file. This avoids a lot of allocations and could potentially speed up performance slightly :fire: 

Also fixed the warnings produced by `clippy`, or added `allow` annotations for places where it does not make sense to change to the suggested alternative. With this, the CI will also deny all warnings going forward :100: 