### PR TITLE
Compare all output files in regression CI

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -57,17 +57,18 @@ jobs:
       run: |
         # Compare the results from both branches, output results as step summary
         sudo apt install pngnq 
-        printf "\n\n##### Comparing without depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
+        printf "\n\n### Comparing without depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
         pngcomp pullautus_main.png pullautus_pr.png | tee -a pngcomp.txt $GITHUB_STEP_SUMMARY
-        printf "\n\n##### Comparing with depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
+        printf "\n\n### Comparing with depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
         pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
-        printf "\n\n##### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
-        diff -qs temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+        printf "\n\n### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
+        diff -q temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
         # do another one that will show all the changes, but as a file instead
         diff temp_main/ temp_pr/ > diff.patch
 
     
     - name: Upload results
+      id: upload
       uses: actions/upload-artifact@v4
       with:
         name: regression-results
@@ -80,6 +81,9 @@ jobs:
           pngcomp_depr.txt
           diff.patch
         overwrite: true # we need subsequent runs to overwrite the result
+
+    - name: Output Artifact URl
+      run: echo 'Artifacts can be downloaded [here](${{ steps.upload.outputs.artifact-url }})' >> $GITHUB_STEP_SUMMARY
 
     - name: Check for differences
       run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -51,6 +51,9 @@ jobs:
 
     - name: Compare results (pngcomp)
       id: compare
+        # The diff command gives exit status of 1 if files differ, but we do not want
+        # to fail the job since we want to see the artifacts in that case.
+      continue-on-error: true
       run: |
         # Compare the results from both branches, output results as step summary
         sudo apt install pngnq 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -4,6 +4,15 @@ on:
 
 name: "Regression"
 
+env:
+  # always emit backtraces on crashes (to help debugging)
+  RUST_BACKTRACE: 1
+  # cargo should always emit color
+  CARGO_TERM_COLOR: always
+  # always output detailed logs with color
+  RUST_LOG: trace
+  RUST_LOG_STYLE: always
+
 jobs:
   compare-results:
     runs-on: ubuntu-latest
@@ -25,11 +34,10 @@ jobs:
       id: run_pr_branch
       run: |
         echo "Running code on PR branch"
-        compare -list resource
         cargo run --release -- test_file.laz
         mv pullautus.png pullautus_pr.png
         mv pullautus_depr.png pullautus_depr_pr.png
-        rm -rf temp/
+        mv temp/ temp_pr/
 
     - name: Download, extract and run latest release
       run: |
@@ -39,6 +47,7 @@ jobs:
         ./pullauta ../test_file.laz
         mv pullautus.png ../pullautus_main.png
         mv pullautus_depr.png ../pullautus_depr_main.png
+        mv temp/ ../temp_main/
 
     - name: Compare results (pngcomp)
       id: compare
@@ -49,6 +58,11 @@ jobs:
         pngcomp pullautus_main.png pullautus_pr.png | tee -a pngcomp.txt $GITHUB_STEP_SUMMARY
         printf "\n\n##### Comparing with depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
         pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+        printf "\n\n##### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
+        diff -qs temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+        # do another one that will show all the changes, but as a file instead
+        diff temp_main/ temp_pr/ > diff.patch
+
     
     - name: Upload results
       uses: actions/upload-artifact@v4
@@ -61,6 +75,7 @@ jobs:
           pullautus_depr_main.png
           pullautus_depr_pr.png
           pngcomp_depr.txt
+          diff.patch
         overwrite: true # we need subsequent runs to overwrite the result
 
     - name: Check for differences

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,12 @@ on:
 
 name: "CI"
 
+env:
+  # always emit backtraces on crashes (to help debugging in tests)
+  RUST_BACKTRACE: 1
+  # cargo should always emit color
+  CARGO_TERM_COLOR: always
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Improve the regression CI job to not only compare the final output images, but also the entire `temp` directory. That way, changes to eg. the `dxf` files can be caught. For now it's not setup to fail the job if the directories are different, as long as the output images are the same, but it will add information to the summary page for each different file, and also generate a git-like patch file showing the differences which can be downloaded as an artifact. See [this](https://github.com/antbern/rusty-pullauta/actions/runs/11220922722) for an example job with diff output appended at the bottom of the summary page :rocket:

I see you haven't defined the `KP_TEST_LAZ_URL` variable for the regression testing yet. If you want you can use this until you get something setup, which is just the same file as I've shared before: `https://drive.usercontent.google.com/download?id=1x2SwLi61-W1OdwUxrG2TJnJo2Oo8INck&confirm=xxx` 🤖 