### PR TITLE
provide execution time in regression CI summary

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -32,7 +32,8 @@ jobs:
       id: run_pr_branch
       run: |
         echo "Running code on PR branch"
-        cargo run --release -- test_file.laz
+        cargo build --release
+        env time -o time_pr.txt target/release/pullauta test_file.laz
         mv pullautus.png pullautus_pr.png
         mv pullautus_depr.png pullautus_depr_pr.png
         mv temp/ temp_pr/
@@ -42,7 +43,7 @@ jobs:
         # in a new folder to make sure we have a clean environment
         mkdir latest_release && cd latest_release
         curl -L https://github.com/rphlo/karttapullautin/releases/latest/download/karttapullautin-x86_64-linux.tar.gz | tar xvz
-        ./pullauta ../test_file.laz
+        env time -o ../time_main.txt ./pullauta ../test_file.laz
         mv pullautus.png ../pullautus_main.png
         mv pullautus_depr.png ../pullautus_depr_main.png
         mv temp/ ../temp_main/
@@ -59,12 +60,18 @@ jobs:
         pngcomp pullautus_main.png pullautus_pr.png | tee -a pngcomp.txt $GITHUB_STEP_SUMMARY
         printf "\n\n### Comparing with depressions:\n" | tee -a $GITHUB_STEP_SUMMARY
         pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+
         printf "\n\n### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
         diff -q temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
         # do another one that will show all the changes, but as a file instead
         diff temp_main/ temp_pr/ > diff.patch
 
-    
+        printf "\n\n### Execution time comparison:\n" | tee -a $GITHUB_STEP_SUMMARY
+        printf "**Latest Release**\n" | tee -a $GITHUB_STEP_SUMMARY
+        cat time_main.txt | tee -a $GITHUB_STEP_SUMMARY
+        printf "\n**PR**\n" | tee -a $GITHUB_STEP_SUMMARY
+        cat time_pr.txt | tee -a $GITHUB_STEP_SUMMARY
+
     - name: Upload results
       id: upload
       uses: actions/upload-artifact@v4
@@ -78,6 +85,8 @@ jobs:
           pullautus_depr_pr.png
           pngcomp_depr.txt
           diff.patch
+          time_pr.txt
+          time_main.txt
         overwrite: true # we need subsequent runs to overwrite the result
 
     - name: Output Artifact URL


### PR DESCRIPTION
Add additional information to the regression CI job summary that compares the execution time of the PR and latest release executions. This will make it easier to measure performance improvements :rocket: 

Example of additional output:

```
Execution time comparison:
Latest Release
90.03user 4.54system 1:34.59elapsed 99%CPU (0avgtext+0avgdata 1094812maxresident)k
0inputs+3613768outputs (0major+350214minor)pagefaults 0swaps

PR
89.29user 4.47system 1:33.77elapsed 99%CPU (0avgtext+0avgdata 1096120maxresident)k
0inputs+3613768outputs (0major+307081minor)pagefaults 0swaps
```

It shows execution time (user and system), CPU utilization, Maximum resident set size of the process during its lifetime in Kbytes and other good stuff. See [man time](https://www.man7.org/linux/man-pages/man1/time.1.html) under _GNU VERSION_ for more information :100: 