### PR TITLE
Introduce `Vec2D` type and clean up cliffs generation

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -50,9 +50,6 @@ jobs:
 
     - name: Compare results (pngcomp)
       id: compare
-        # The diff command gives exit status of 1 if files differ, but we do not want
-        # to fail the job since we want to see the artifacts in that case.
-      continue-on-error: true
       run: |
         # Compare the results from both branches, output results as step summary
         sudo apt install pngnq 
@@ -62,15 +59,16 @@ jobs:
         pngcomp pullautus_depr_main.png pullautus_depr_pr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
 
         printf "\n\n### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
-        diff -q temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+        diff -q temp_main/ temp_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY || true
         # do another one that will show all the changes, but as a file instead
-        diff temp_main/ temp_pr/ > diff.patch
+        diff temp_main/ temp_pr/ > diff.patch || true
 
         printf "\n\n### Execution time comparison:\n" | tee -a $GITHUB_STEP_SUMMARY
         printf "**Latest Release**\n" | tee -a $GITHUB_STEP_SUMMARY
         cat time_main.txt | tee -a $GITHUB_STEP_SUMMARY
         printf "\n**PR**\n" | tee -a $GITHUB_STEP_SUMMARY
         cat time_pr.txt | tee -a $GITHUB_STEP_SUMMARY
+
 
     - name: Upload results
       id: upload
@@ -173,9 +171,6 @@ jobs:
 
     - name: Compare results (pngcomp)
       id: compare
-        # The diff command gives exit status of 1 if files differ, but we do not want
-        # to fail the job since we want to see the artifacts in that case.
-      continue-on-error: true
       run: |
         # Compare the results from both branches, output results as step summary
         sudo apt install pngnq
@@ -185,9 +180,9 @@ jobs:
         pngcomp output_main/merged_depr.png output_pr/merged_depr.png | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
 
         printf "\n\n### Comparing directory contents using diff:\n" | tee -a $GITHUB_STEP_SUMMARY
-        diff -qr output_main/ output_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY
+        diff -qr output_main/ output_pr/ | tee -a pngcomp_depr.txt $GITHUB_STEP_SUMMARY || true
         # do another one that will show all the changes, but as a file instead
-        diff -r output_main/ output_pr/ > diff.patch
+        diff -r output_main/ output_pr/ > diff.patch || true
 
         printf "\n\n### Execution time comparison:\n" | tee -a $GITHUB_STEP_SUMMARY
         printf "**Latest Release**\n" | tee -a $GITHUB_STEP_SUMMARY

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -97,7 +97,7 @@ impl Canvas {
     }
 
     #[inline]
-    pub fn draw_filled_polygon(&mut self, apts: &Vec<Vec<(f32, f32)>>) {
+    pub fn draw_filled_polygon(&mut self, apts: &[Vec<(f32, f32)>]) {
         let new_path = Path::new();
         let _ = mem::replace(&mut self.path, new_path);
         self.paint.set_stroke_width(1.0);

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -284,25 +284,19 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                         let temp = h0 - ht;
                         let dist = ((x0 - xt).powi(2) + (y0 - yt).powi(2)).sqrt();
                         if dist > 0.0 {
+                            let imgx = ((x0 + xt) / 2.0 - xmin + 0.5).floor() as u32;
+                            let imgy = ((y0 + yt) / 2.0 - ymin + 0.5).floor() as u32;
                             if steep < no_small_ciffs
                                 && temp > limit
                                 && temp > (limit + (dist - limit) * 0.85)
-                                && (((x0 + xt) / 2.0 - xmin + 0.5).floor() as u32) < img.width()
-                                && (((y0 + yt) / 2.0 - ymin + 0.5).floor() as u32) < img.height()
+                                && imgx < img.width()
+                                && imgy < img.height()
                             {
-                                let p = img.get_pixel(
-                                    ((x0 + xt) / 2.0 - xmin + 0.5).floor() as u32,
-                                    ((y0 + yt) / 2.0 - ymin + 0.5).floor() as u32,
-                                );
+                                let p = img.get_pixel(imgx, imgy);
                                 if p[0] == 255 {
-                                    img.put_pixel(
-                                        ((x0 + xt) / 2.0 - xmin + 0.5).floor() as u32,
-                                        ((y0 + yt) / 2.0 - ymin + 0.5).floor() as u32,
-                                        Rgb([0, 0, 0]),
-                                    );
+                                    img.put_pixel(imgx, imgy, Rgb([0, 0, 0]));
                                     f2.write_all(
-                                        "POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff2\r\n  0\r\n"
-                                            .as_bytes(),
+                                        b"POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff2\r\n  0\r\n",
                                     )
                                     .expect("Cannot write dxf file");
                                     write!(
@@ -317,10 +311,8 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                             }
 
                             if temp > limit2 && temp > (limit2 + (dist - limit2) * 0.85) {
-                                f3.write_all(
-                                    "POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff3\r\n  0\r\n".as_bytes(),
-                                )
-                                .expect("Cannot write dxf file");
+                                f3.write_all(b"POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff3\r\n  0\r\n")
+                                    .expect("Cannot write dxf file");
                                 write!(
                                     &mut f3,
                                     "VERTEX\r\n  8\r\ncliff3\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nVERTEX\r\n  8\r\ncliff3\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nSEQEND\r\n  0\r\n",
@@ -337,7 +329,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         }
     }
 
-    f2.write_all("ENDSEC\r\n  0\r\nEOF\r\n".as_bytes())
+    f2.write_all(b"ENDSEC\r\n  0\r\nEOF\r\n")
         .expect("Cannot write dxf file");
     let c2_limit = 2.6 * 2.75;
 
@@ -404,10 +396,8 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                         let temp = h0 - ht;
                         let dist = ((x0 - xt).powi(2) + (y0 - yt).powi(2)).sqrt();
                         if dist > 0.0 && temp > limit && temp > (limit + (dist - limit) * 0.85) {
-                            f3.write_all(
-                                "POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff4\r\n  0\r\n".as_bytes(),
-                            )
-                            .expect("Cannot write dxf file");
+                            f3.write_all(b"POLYLINE\r\n 66\r\n1\r\n  8\r\ncliff4\r\n  0\r\n")
+                                .expect("Cannot write dxf file");
                             write!(
                                 &mut f3,
                                 "VERTEX\r\n  8\r\ncliff4\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nVERTEX\r\n  8\r\ncliff4\r\n 10\r\n{}\r\n 20\r\n{}\r\n  0\r\nSEQEND\r\n  0\r\n",
@@ -423,7 +413,7 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
         }
     }
 
-    f3.write_all("ENDSEC\r\n  0\r\nEOF\r\n".as_bytes())
+    f3.write_all(b"ENDSEC\r\n  0\r\nEOF\r\n")
         .expect("Cannot write dxf file");
     img.save(tmpfolder.join("c2.png"))
         .expect("could not save output png");

--- a/src/cliffs.rs
+++ b/src/cliffs.rs
@@ -226,28 +226,23 @@ pub fn makecliffs(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                     // since we need to modify it, we need to convert it to mutable
                     // this will actually mutate the outer `d`
                     let d = d.to_mut();
-                    let b = ((d.len() - 1) as f64 / 30.0).floor() as usize;
-                    let mut i: usize = 0;
-                    while i < d.len() {
-                        let mut e = i + b;
-                        if e > d.len() {
-                            e = d.len();
-                        }
-                        let _: Vec<_> = d.drain(i..e).collect();
-                        i += 1;
-                    }
+
+                    // if d has too many points, thin it by keeping every b point
+                    let b = ((d.len() - 1) as f64 / 30.0).floor() as usize + 1;
+                    let mut idx = 0;
+                    d.retain(|_| {
+                        idx += 1;
+                        idx % b == 0
+                    });
                 }
                 if t.len() > 301 {
-                    let b = ((t.len() - 1) as f64 / 300.0).floor() as usize;
-                    let mut i: usize = 0;
-                    while i < t.len() {
-                        let mut e = i + b;
-                        if e > t.len() {
-                            e = t.len();
-                        }
-                        let _: Vec<_> = t.drain(i..e).collect();
-                        i += 1;
-                    }
+                    // if t has too many points, thin it by keeping every b point
+                    let b = ((t.len() - 1) as f64 / 300.0).floor() as usize + 1;
+                    let mut idx = 0;
+                    t.retain(|_| {
+                        idx += 1;
+                        idx % b == 0
+                    })
                 }
                 let mut temp_max: f64 = f64::MIN;
                 let mut temp_min: f64 = f64::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 // we use a lot of manual indices instead of `take` and `skip`, so allow that
 #![allow(clippy::needless_range_loop)]
+// make sure any use of unsafe is documented
+#![deny(clippy::undocumented_unsafe_blocks)]
 
 pub mod blocks;
 pub mod canvas;
@@ -12,4 +14,5 @@ pub mod merge;
 pub mod process;
 pub mod render;
 pub mod util;
+pub mod vec2d;
 pub mod vegetation;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::util::{read_lines, read_lines_no_alloc};
+use crate::vec2d::Vec2D;
 
 fn merge_png(
     config: &Config,
@@ -570,7 +571,8 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
     })
     .expect("error reading xyz file");
 
-    let mut steepness = vec![vec![f64::NAN; (ymax + 1) as usize]; (xmax + 1) as usize];
+    let mut steepness = Vec2D::new((xmax + 1) as usize, (ymax + 1) as usize, f64::NAN);
+
     for i in 1..xmax {
         for j in 1..ymax {
             let mut low: f64 = f64::MAX;
@@ -586,7 +588,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                     }
                 }
             }
-            steepness[i as usize][j as usize] = high - low;
+            steepness[(i as usize, j as usize)] = high - low;
         }
     }
     let input = tmpfolder.join("out.dxf");
@@ -880,7 +882,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                     for k in 0..(el_x_len - 1) {
                         let xx = ((el_x[l][k] - xstart) / size + 0.5).floor() as usize;
                         let yy = ((el_y[l][k] - ystart) / size + 0.5).floor() as usize;
-                        let ss = steepness[xx][yy];
+                        let ss = steepness[(xx, yy)];
                         if minele > h - 0.5 * ss {
                             minele = h - 0.5 * ss;
                         }
@@ -947,7 +949,7 @@ pub fn smoothjoin(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn Error
                     for k in 1..(el_x_len - 1) {
                         let xx = ((el_x[l][k] - xstart) / size + 0.5).floor() as usize;
                         let yy = ((el_y[l][k] - ystart) / size + 0.5).floor() as usize;
-                        let ss = steepness[xx][yy];
+                        let ss = steepness[(xx, yy)];
                         if ss.is_nan() || ss < 0.5 {
                             if ((xpre - el_x[l][k]).powi(2) + (ypre - el_y[l][k]).powi(2)).sqrt()
                                 >= 4.0

--- a/src/render.rs
+++ b/src/render.rs
@@ -1065,7 +1065,7 @@ pub fn mtkshaperender(config: &Config, tmpfolder: &Path) -> Result<(), Box<dyn E
     while i < ((h * 600.0 / 254.0 / scalefactor + 500.0) as f32) {
         i += 14.0;
         let wd = (w * 600.0 / 254.0 / scalefactor + 2.0) as f32;
-        imgmarsh.draw_filled_polygon(&vec![vec![
+        imgmarsh.draw_filled_polygon(&[vec![
             (-1.0, i),
             (wd, i),
             (wd, i + 10.0),

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -1,7 +1,6 @@
-
-/// Vector for storing 2-dimensional data in a contigous memory block, removes one layer of indirection.
+/// Vector for storing 2-dimensional grid-like data in a contigous memory block, removes one layer of indirection.
 pub struct Vec2D<T> {
-    data: Vec<T>,
+    data: Box<[T]>, // the size is fixed, so we can use a Box slice instead of Vec
     w: usize,
     h: usize,
 }
@@ -12,7 +11,7 @@ impl<T> Vec2D<T> {
         T: Clone,
     {
         Vec2D {
-            data: vec![default; w * h],
+            data: vec![default; w * h].into(),
             w,
             h,
         }
@@ -55,7 +54,7 @@ mod tests {
         let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 0);
         assert_eq!(vec2d.w, 3);
         assert_eq!(vec2d.h, 2);
-        assert_eq!(vec2d.data, vec![0; 6]);
+        assert_eq!(vec2d.data, vec![0; 6].into());
     }
 
     #[test]
@@ -63,6 +62,20 @@ mod tests {
         let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
         assert_eq!(vec2d[(0, 0)], 1);
         assert_eq!(vec2d[(2, 1)], 1);
+    }
+
+    #[test]
+    fn test_index_skewed_0() {
+        let vec2d: Vec2D<i32> = Vec2D::new(10, 2, 1);
+        assert_eq!(vec2d[(9, 0)], 1);
+        assert_eq!(vec2d[(9, 1)], 1);
+    }
+
+    #[test]
+    fn test_index_skewed_1() {
+        let vec2d: Vec2D<i32> = Vec2D::new(3, 10, 1);
+        assert_eq!(vec2d[(0, 9)], 1);
+        assert_eq!(vec2d[(2, 9)], 1);
     }
 
     #[test]
@@ -83,6 +96,20 @@ mod tests {
         let mut vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
         vec2d[(1, 1)] = 5;
         assert_eq!(vec2d[(1, 1)], 5);
+    }
+
+    #[test]
+    fn test_index_mut_skewed_0() {
+        let mut vec2d: Vec2D<i32> = Vec2D::new(10, 2, 1);
+        vec2d[(9, 1)] = 5;
+        assert_eq!(vec2d[(9, 1)], 5);
+    }
+
+    #[test]
+    fn test_index_mut_skewed_1() {
+        let mut vec2d: Vec2D<i32> = Vec2D::new(3, 10, 1);
+        vec2d[(2, 9)] = 5;
+        assert_eq!(vec2d[(2, 9)], 5);
     }
 
     #[test]

--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -1,0 +1,101 @@
+
+/// Vector for storing 2-dimensional data in a contigous memory block, removes one layer of indirection.
+pub struct Vec2D<T> {
+    data: Vec<T>,
+    w: usize,
+    h: usize,
+}
+
+impl<T> Vec2D<T> {
+    pub fn new(w: usize, h: usize, default: T) -> Vec2D<T>
+    where
+        T: Clone,
+    {
+        Vec2D {
+            data: vec![default; w * h],
+            w,
+            h,
+        }
+    }
+}
+
+impl<T> std::ops::Index<(usize, usize)> for Vec2D<T> {
+    type Output = T;
+
+    fn index(&self, index: (usize, usize)) -> &T {
+        if index.0 >= self.w || index.1 >= self.h {
+            panic!(
+                "index out of bounds: the len is ({}, {}) but the index is ({}, {})",
+                self.w, self.h, index.0, index.1
+            );
+        }
+        // SAFETY: the index is checked to be within bounds
+        unsafe { self.data.get_unchecked(index.0 * self.h + index.1) }
+    }
+}
+
+impl<T> std::ops::IndexMut<(usize, usize)> for Vec2D<T> {
+    fn index_mut(&mut self, index: (usize, usize)) -> &mut T {
+        if index.0 >= self.w || index.1 >= self.h {
+            panic!(
+                "index out of bounds: the len is ({}, {}) but the index is ({}, {})",
+                self.w, self.h, index.0, index.1
+            );
+        }
+        // SAFETY: the index is checked to be within bounds
+        unsafe { self.data.get_unchecked_mut(index.0 * self.h + index.1) }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 0);
+        assert_eq!(vec2d.w, 3);
+        assert_eq!(vec2d.h, 2);
+        assert_eq!(vec2d.data, vec![0; 6]);
+    }
+
+    #[test]
+    fn test_index() {
+        let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        assert_eq!(vec2d[(0, 0)], 1);
+        assert_eq!(vec2d[(2, 1)], 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is (3, 2) but the index is (3, 0)")]
+    fn test_index_out_of_bounds_0() {
+        let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        let _ = vec2d[(3, 0)];
+    }
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is (3, 2) but the index is (0, 2)")]
+    fn test_index_out_of_bounds_1() {
+        let vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        let _ = vec2d[(0, 2)];
+    }
+
+    #[test]
+    fn test_index_mut() {
+        let mut vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        vec2d[(1, 1)] = 5;
+        assert_eq!(vec2d[(1, 1)], 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is (3, 2) but the index is (3, 0)")]
+    fn test_index_mut_out_of_bounds_0() {
+        let mut vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        vec2d[(3, 0)] = 5;
+    }
+
+    #[test]
+    #[should_panic(expected = "index out of bounds: the len is (3, 2) but the index is (0, 2)")]
+    fn test_index_mut_out_of_bounds_1() {
+        let mut vec2d: Vec2D<i32> = Vec2D::new(3, 2, 1);
+        vec2d[(0, 2)] = 5;
+    }
+}


### PR DESCRIPTION
Instead of using `Vec<Vec<T>>>`  for grid-like data, this introduces a new type `Vec2D` which stores the 2d grid in a contiguous memory region instead of using a vector of pointers to other vectors (which might be spread out across the memory). Regression tests show no major decrease in execution time, but a reduction in the number of minor page faults (read [here](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_for_real_time/9/html/understanding_rhel_for_real_time/assembly_memory-management-on-rhel-for-real-time-_understanding-rhel-for-real-time-core-concepts#con_major-and-minor-page-faults_assembly_memory-management-on-rhel-for-real-time-) for explanation), which most likely more has an effect when running on older/slower hardware. 

Also went through and simplified and optimized some memory allocations in `cliffs.rs` and a small fix to the regression test so that it does not fail before outputting the information when there is a difference in the files :rocket: 